### PR TITLE
Add support for Redmine 5.0

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -1,5 +1,7 @@
 require 'redmine'
 
+$LOAD_PATH.unshift "#{File.dirname(__FILE__)}/lib"
+
 require_dependency 'mail_handler_patch'
 require_dependency 'chat_hook_listener'
 

--- a/lib/chat_helper.rb
+++ b/lib/chat_helper.rb
@@ -21,10 +21,13 @@ require 'uri'
 require 'open-uri'
 require 'json'
 
-module Redmine
-  module Helpers
-    module Chat
+module ChatHelper
+  def self.included(base) # :nodoc:
+    base.send(:include, InstanceModules)
+  end
 
+  module InstanceModules
+    module Chat
       # Return hash with data from issue and journals (optional) objects
       #
       # Based on template from redmine/app/views/issues/show.api.rsb
@@ -221,3 +224,5 @@ module Redmine
     end
   end
 end
+
+Redmine::Helpers.send(:include, ChatHelper)


### PR DESCRIPTION
> #### [Redmine 5.0.0, 4.2.5 and 4.1.7 released](https://www.redmine.org/news/135)
> 
> 1. Migrate to Rails 6.1 with Zeitwerk autoloading ([#29914](https://www.redmine.org/issues/29914)). Switching to [Zeitwerk autoloader](https://guides.rubyonrails.org/classic_to_zeitwerk_howto.html) breaks some plugins and requires plugin developers to fix the compatibility issues.