### PR TITLE
Add mentioned_users field

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,13 +238,19 @@ Data field contains information about issue that is similar to format of Redmine
           "name": "Redmine Admin"
         },
         "subject": "Test issue",
-        "description": "",
+        "description": "Hello, @testuser1!",
         "start_date": "2017-09-19",
         "due_date": null,
         "done_ratio": 0,
         "is_private": false,
         "estimated_hours": null,
         "spent_hours": 0.0,
+        "mentioned_users": [
+          {
+            "id": 5,
+            "name": "Test user 1"
+          }
+        ],
         "custom_fields": [],
         "created_on": "2017-09-19T12:14:43Z",
         "updated_on": "2017-09-19T12:14:43Z",
@@ -402,10 +408,16 @@ Data field contains information about issue that is similar to format of Redmine
               "id": 5,
               "name": "Test user 1"
             },
-            "notes": "Message",
+            "notes": "Hello, @admin!",
             "private_notes": false,
             "created_on": "2017-09-19T12:43:44Z",
             "details": [
+            ],
+            "mentioned_users": [
+              {
+                "id": 1,
+                "name": "Redmine Admin"
+              }
             ]
           }
         ],

--- a/lib/chat_helper.rb
+++ b/lib/chat_helper.rb
@@ -84,6 +84,18 @@ module ChatHelper
         json[:estimated_hours] = issue.estimated_hours
         json[:spent_hours] = issue.spent_hours
 
+        begin
+          unless issue.mentioned_users.nil?
+            json[:mentioned_users] = []
+            issue.mentioned_users.each do |mentioned_user|
+              json[:mentioned_users] += [{:id => mentioned_user.id, :name => mentioned_user.name}]
+            end
+          end
+        rescue NoMethodError
+          # `mentioned_users` method was added in Redmine 5.0. So we should ignore exception
+          # until support for Redmine 4.2 will be dropped.
+        end
+
         # Custom values
         unless issue.custom_field_values.nil?
           json[:custom_fields] = []
@@ -154,6 +166,19 @@ module ChatHelper
                 :new_value => detail.value
               }]
             end
+
+            begin
+              unless journal.mentioned_users.nil?
+                j[:mentioned_users] = []
+                journal.mentioned_users.each do |mentioned_user|
+                  j[:mentioned_users] += [{:id => mentioned_user.id, :name => mentioned_user.name}]
+                end
+              end
+            rescue NoMethodError
+              # `mentioned_users` method was added in Redmine 5.0. So we should ignore exception
+              # until support for Redmine 4.2 will be dropped.
+            end
+
             json[:journals] += [j]
           end
         end


### PR DESCRIPTION
From Redmine release notes:

> #### [Redmine 5.0.0, 4.2.5 and 4.1.7 released](https://www.redmine.org/news/135)
> 
> 3. Users can be mention now using arobase autocomplete by other users with add watchers permission ([#13919](https://www.redmine.org/issues/13919)). This a long awaited feature.