### PR TITLE
Add support for Localizable plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,15 +223,27 @@ Data field contains information about issue that is similar to format of Redmine
         },
         "tracker": {
           "id": 1,
-          "name": "Bug"
+          "name": {
+            "default": "Bug",
+            "en": "Bug",
+            "ru": "Ошибка"
+          }
         },
         "status": {
           "id": 1,
-          "name": "New"
+          "name": {
+            "default": "New",
+            "en": "New",
+            "ru": "Новая"
+          }
         },
         "priority": {
           "id": 2,
-          "name": "Normal"
+          "name": {
+            "default": "Normal",
+            "en": "Normal",
+            "ru": "Нормальный"
+          }
         },
         "author": {
           "id": 1,
@@ -374,15 +386,27 @@ Data field contains information about issue that is similar to format of Redmine
         },
         "tracker": {
           "id": 1,
-          "name": "Bug"
+          "name": {
+            "default": "Bug",
+            "en": "Bug",
+            "ru": "Ошибка"
+          }
         },
         "status": {
           "id": 1,
-          "name": "New"
+          "name": {
+            "default": "New",
+            "en": "New",
+            "ru": "Новая"
+          }
         },
         "priority": {
           "id": 2,
-          "name": "Normal"
+          "name": {
+            "default": "Normal",
+            "en": "Normal",
+            "ru": "Нормальный"
+          }
         },
         "author": {
           "id": 1,

--- a/app/views/settings/_nxs_chat.html.erb
+++ b/app/views/settings/_nxs_chat.html.erb
@@ -1,20 +1,27 @@
-<table>
-  <tbody>
-    <tr>
-      <th><%= l(:label_chat_notifications_endpoint) %>:</th>
-      <td>
-        <input type="text" id="settings_notifications_endpoint"
-                           value="<%= settings['notifications_endpoint'] %>"
-                           name="settings[notifications_endpoint]"
-                           size="50">
-      </td>
-    </tr>
-    <tr>
-      <th><%= l(:label_chat_notifications_endpoint_ssl_verify_none) %>:</th>
-      <td>
-        <%= check_box_tag "settings[notifications_endpoint_ssl_verify_none]", true, settings['notifications_endpoint_ssl_verify_none'] %>
-      </td>
-    </tr>
-  </tbody>
-</table>
+<p>
+  <label><%= l(:label_chat_notifications_endpoint) %>:</label>
+  <input type="text" id="settings_notifications_endpoint"
+         value="<%= settings['notifications_endpoint'] %>"
+         name="settings[notifications_endpoint]"
+         size="50">
+</p>
 
+<p>
+  <label><%= l(:label_chat_notifications_endpoint_ssl_verify_none) %>:</label>
+  <%= check_box_tag "settings[notifications_endpoint_ssl_verify_none]", true, settings['notifications_endpoint_ssl_verify_none'] %>
+</p>
+
+<p>
+  <% @settings['notifications_locales'] = [] if @settings['notifications_locales'].nil? %>
+
+  <label><%= l(:label_chat_notifications_locales) %>:</label>
+  <% for locale in valid_languages %>
+  <label class="block">
+    <%= check_box_tag "settings[notifications_locales][]",
+                      locale,
+                      (settings['notifications_locales'].include? locale.to_s),
+                      :id => "settings_notifications_locales_#{locale}" %>
+    <%= ll(locale.to_s, :general_lang_name) %>
+  </label>
+  <% end %>
+</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,3 +3,4 @@ en:
   # Settings
   label_chat_notifications_endpoint: "URL for notifications"
   label_chat_notifications_endpoint_ssl_verify_none: "Disable SSL verification"
+  label_chat_notifications_locales: "Additional languages for notifications"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -3,3 +3,4 @@ ru:
   # Settings
   label_chat_notifications_endpoint: "URL для уведомлений"
   label_chat_notifications_endpoint_ssl_verify_none: "Отключить верификацию SSL"
+  label_chat_notifications_locales: "Дополнительные языки для уведомлений"

--- a/init.rb
+++ b/init.rb
@@ -9,10 +9,9 @@ Redmine::Plugin.register :nxs_chat do
   name 'nxs-chat'
   author 'Nixys Ltd.'
   description 'Plugin for integration with nxs-chat-srv (Telegram bot by Nixys)'
-  version '2.0'
+  version '4.0.0'
   url 'https://github.com/nixys/nxs-chat-redmine'
   author_url 'https://nixys.ru/'
 
   settings :default => {'empty' => true}, :partial => 'settings/nxs_chat'
 end
-

--- a/lib/chat_helper.rb
+++ b/lib/chat_helper.rb
@@ -101,7 +101,7 @@ module ChatHelper
         json[:priority] = {:id => issue.priority_id, :name => localize(issue.priority.method(:name))} unless issue.priority.nil?
         json[:author] = {:id => issue.author_id, :name => issue.author.name} unless issue.author.nil?
         json[:assigned_to] = {:id => issue.assigned_to_id, :name => issue.assigned_to.name} unless issue.assigned_to.nil?
-        json[:category] = {:id => issue.category_id, :name => issue.category.name} unless issue.category.nil?
+        json[:category] = {:id => issue.category_id, :name => localize(issue.category.method(:name))} unless issue.category.nil?
         json[:fixed_version] = {:id => issue.fixed_version_id, :name => issue.fixed_version.name} unless issue.fixed_version.nil?
         json[:parent] = {:id => issue.parent_id} unless issue.parent.nil?
 
@@ -130,7 +130,7 @@ module ChatHelper
         unless issue.custom_field_values.nil?
           json[:custom_fields] = []
           issue.custom_field_values.each do |custom_value|
-            attrs = {:id => custom_value.custom_field_id, :name => custom_value.custom_field.name}
+            attrs = {:id => custom_value.custom_field_id, :name => localize(custom_value.custom_field.method(:name))}
             attrs.merge!(:multiple => true) if custom_value.custom_field.multiple?
 
             if custom_value.value.is_a?(Array)


### PR DESCRIPTION
Basic support for [localizable](https://www.redmine.org/plugins/localizable) plugin (`category`, `custom_fields`, `priority`, `status`, `tracker` fields can be translated now).